### PR TITLE
axe-core getRules Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ library used for scanning for accessibility issues and providing guidance on how
 
 ## Table of Contents
 
-- [Playwright Axe](#playwright-axe)
+- [Pytest Playwright Axe](#pytest-playwright-axe)
   - [Table of Contents](#table-of-contents)
   - [Using the Axe class](#using-the-axe-class)
   - [.run(): Single page scan](#run-single-page-scan)
@@ -18,6 +18,11 @@ library used for scanning for accessibility issues and providing guidance on how
     - [Optional arguments](#optional-arguments-1)
     - [Returns](#returns-1)
     - [Example usage](#example-usage-1)
+  - [.get\_rules(): Return rules](#get_rules-return-rules)
+    - [Required Arguments](#required-arguments-2)
+    - [Optional Arguments](#optional-arguments-2)
+    - [Returns](#returns-2)
+    - [Example usage](#example-usage-2)
   - [Rulesets](#rulesets)
   - [Example Reports](#example-reports)
   - [Versioning](#versioning)
@@ -47,6 +52,8 @@ By default, the `Axe.run(page)` command will do the following:
 - Any steps after the `Axe.run()` command will continue to execute, and it will not cause the test in progress to fail (it runs a passive scan of the page)
 - Will return the full response from axe-core as a dict object if the call is set to a variable, e.g. `axe_results = Axe.run(page)` will populate `axe_results` to interact with as required
 
+This uses the [axe-core run method outlined in the axe-core documentation](https://www.deque.com/axe/core-documentation/api-documentation/#api-name-axerun).
+
 ### Required arguments
 
 The following are required for `Axe.run()`:
@@ -69,7 +76,7 @@ The `Axe.run(page)` has the following optional arguments that can be passed in:
 | `strict_mode`              | `bool` | `True`, `False`                                                                                                   | `False`       | If True, when a violation is found an AxeAccessibilityException is raised, causing a test failure.                                                                                                                                                                      |
 | `html_report_generated`    | `bool` | `True`, `False`                                                                                                   | `True`        | If True, a HTML report will be generated summarising the axe-core findings.                                                                                                                                                                                             |
 | `json_report_generated`    | `bool` | `True`, `False`                                                                                                   | `True`        | If True, a JSON report will be generated with the full axe-core findings.                                                                                                                                                                                               |
-| `use_minified_file`        | `bool` | `True`, `False`                                                                                                   | `False`       | If True, use the minified version of axe-core (axe.min.js).  If not provided (default), use the full version of axe-core (axe.js).                                                                                                                                      |
+| `use_minified_file`        | `bool` | `True`, `False`                                                                                                   | `False`       | _This will be available in the next update (after 4.10.3)._ If True, use the minified version of axe-core (axe.min.js).  If not provided (default), use the full version of axe-core (axe.js).                                                                          |
 
 ### Returns
 
@@ -132,7 +139,7 @@ The `Axe.run_list(page, page_list)` function has the following optional argument
 | `strict_mode`              | `bool` | `True`, `False`                                                                                                   | `False`       | If True, when a violation is found an AxeAccessibilityException is raised, causing a test failure.                                                                                                                                                                      |
 | `html_report_generated`    | `bool` | `True`, `False`                                                                                                   | `True`        | If True, a HTML report will be generated summarising the axe-core findings.                                                                                                                                                                                             |
 | `json_report_generated`    | `bool` | `True`, `False`                                                                                                   | `True`        | If True, a JSON report will be generated with the full axe-core findings.                                                                                                                                                                                               |
-| `use_minified_file`        | `bool` | `True`, `False`                                                                                                   | `False`       | If True, use the minified version of axe-core (axe.min.js).  If not provided (default), use the full version of axe-core (axe.js).                                                                                                                                      |
+| `use_minified_file`        | `bool` | `True`, `False`                                                                                                   | `False`       | _This will be available in the next update (after 4.10.3)._ If True, use the minified version of axe-core (axe.min.js).  If not provided (default), use the full version of axe-core (axe.js).                                                                          |
 
 ### Returns
 
@@ -153,6 +160,46 @@ When using the following command: `pytest --base-url https://www.github.com`:
             ]
 
         Axe.run_list(page, urls_to_check)
+
+## .get_rules(): Return rules
+
+> _This will be available in the next update (after 4.10.3)._
+
+You can get the rules used for specific tags by using this method, or all rules if no ruleset is provided.
+
+This uses the [axe-core getRules method outlined in the axe-core documentation](https://www.deque.com/axe/core-documentation/api-documentation/#api-name-axegetrules).
+
+### Required Arguments
+
+The following are required for `Axe.get_rules()`:
+
+| Argument | Format                     | Description                                              |
+| -------- | -------------------------- | -------------------------------------------------------- |
+| page     | `playwright.sync_api.Page` | A Playwright Page object.. This page can be empty/blank. |
+
+### Optional Arguments
+
+The `Axe.get_rules(page, page_list)` function has the following optional arguments that can be passed in:
+
+| Argument | Format      | Supported Values                                                                                                                    | Default Value | Description                                                                                               |
+| -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `rules`  | `list[str]` | A Python list with strings representing [valid tags](https://www.deque.com/axe/core-documentation/api-documentation/#axecore-tags). | `None`        | If provided, the list of rules to provide information on.  If not provided, return details for all rules. |
+
+### Returns
+
+A Python `list[dict]` object with all matching rules and their descriptors.
+
+### Example usage
+
+    import logging
+    from pytest_playwright_axe import Axe
+    from playwright.sync_api import Page
+
+    def test_get_rules(page: Page) -> None:
+
+        rules = Axe.get_rules(page, ['wcag21aa])
+        for rule in rules:
+            logging.info(rule)
 
 ## Rulesets
 

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ Example:
 
 The following are examples of the reports generated using this package:
 
-- HTML Format: [Example File](./examples/example_result_report.html)
-- JSON Format: [Example File](./examples/example_result_report.json)
+- HTML Format: [Example File](https://github.com/davethepunkyone/pytest-playwright-axe/tree/main/examples/example_result_report.html)
+- JSON Format: [Example File](https://github.com/davethepunkyone/pytest-playwright-axe/tree/main/examples/example_result_report.json)
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Example:
 
 The following are examples of the reports generated using this package:
 
-- HTML Format: [Example File](https://github.com/davethepunkyone/pytest-playwright-axe/tree/main/examples/example_result_report.html)
+- HTML Format (Use download file to see report): [Example File](https://github.com/davethepunkyone/pytest-playwright-axe/tree/main/examples/example_result_report.html)
 - JSON Format: [Example File](https://github.com/davethepunkyone/pytest-playwright-axe/tree/main/examples/example_result_report.json)
 
 ## Versioning

--- a/src/pytest_playwright_axe/axe.py
+++ b/src/pytest_playwright_axe/axe.py
@@ -150,6 +150,23 @@ class Axe:
         return results
 
     @staticmethod
+    def get_rules(page: Page, rules: list[str] = None) -> list[dict]:
+        """
+        This runs axe.getRules(), returning the specified rules (or all if no ruleset provided).
+
+        Args:
+            page (playwright.sync_api.Page): The page object to execute axe-core against.
+            rules (list[str]): [Optional] A list of rules to return. If not provided, all rules are returned.
+        
+        Returns:
+            list[dict]: A list of dictionaries containing the axe-core rules returned.
+        """
+        page.evaluate(AXE_PATH.read_text(encoding="UTF-8"))
+
+        return page.evaluate(
+            f"axe.getRules({"" if rules is None else str(rules)});")
+
+    @staticmethod
     def _build_run_command(context: str = "", options: str = "") -> str:
         return_str = context if len(context) > 0 else ""
         return_str += ", " if len(return_str) > 0 and len(options) > 0 else ""

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -14,3 +14,8 @@ def test_minified_example(page: Page) -> None:
 
     # Assert repo text is present
     Axe.run(page, options=OPTIONS_WCAG_22AA, use_minified_file=True)
+
+
+def test_get_rules(page: Page) -> None:
+    rules = Axe.get_rules(page, ["wcag2a"])
+    print(rules[0])


### PR DESCRIPTION
This adds a new method to support the getRules() method provided by axe-core.