### PR TITLE
Add py.typed file for type hinting support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
+"pytest_playwright_axe" = ["py.typed"]
 "pytest_playwright_axe.resources" = ["*.js"]
 
 [project]


### PR DESCRIPTION
This adds py.typed support so scanning via type hinting tools does not flag for missing library stubs